### PR TITLE
Added service-mocker to Libraries and Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [sw-precache](https://github.com/GoogleChrome/sw-precache/) - Generates a service worker to cache your local App Shell resources.
 - [sw-appcache-behavior](https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-appcache-behavior) - A service worker implementation of the behavior defined in a page's App Cache manifest.
 - [sw-offline-google-analytics](https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-offline-google-analytics) - A service worker helper library to retry offline Google Analytics requests when a connection is available.
+- [service-mocker](https://github.com/service-mocker/service-mocker) - An API mocking framework based on the `FetchEvent`.
 
 ## Videos
 


### PR DESCRIPTION
Hi there!

We just built an API mocking framework that is based on the service worker API here: https://github.com/service-mocker/service-mocker. Would you be interested in appending it to the `Libraries and Tools` list? 